### PR TITLE
Add game start page and store selections

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -1,0 +1,16 @@
+import $ from 'jquery';
+
+$(function() {
+    const dataStr = localStorage.getItem('gameSetup');
+    if (!dataStr) {
+        $('.game-description').text('Нет данных о настройках игры.');
+        return;
+    }
+    const data = JSON.parse(dataStr);
+    let levelName = '';
+    if (data.flightpathId) {
+        const path = (window.readOnlyData?.flightpaths || []).find(p => p.id == data.flightpathId);
+        levelName = path ? path.title_ru : '';
+    }
+    $('.game-description').text(`Вы выбрали маршрут: ${levelName}. Игра будет загружена позже.`);
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -118,8 +118,9 @@ $(function() {
     const BIND_DELAY = 400;
     let lastWheel = new Date();
 
-    const $swiper = $('#swiper-js'); 
-    const $commonSwiper = $('.swiper-js'); // next-btn in the botom of each slide
+    const $swiper = $('#swiper-js');
+    const $commonSwiper = $('.swiper-js'); // next-btn in the bottom of each slide
+    const $startGameBtn = $('#start-game-btn');
 
     const sectionCount = $('.section-outer').length;
     const SCROLL_MAX = (sectionCount * 100) - 100;
@@ -150,6 +151,19 @@ $(function() {
 
     $commonSwiper.on("click", ()=>{
         pageSlider.goNext();
+    });
+
+    $startGameBtn.on('click', ()=>{
+        const gameSetup = {
+            name: inputName.val(),
+            surname: inputSurname.val(),
+            starshipId: starshipManager.selectedItems[0],
+            equipmentId: equipmentManager.selectedItems[0],
+            flightpathId: flightpathManager.selectedItems[0],
+            crewIds: crewManager.selectedItems
+        };
+        localStorage.setItem('gameSetup', JSON.stringify(gameSetup));
+        window.location.href = 'game.html';
     });
     // NEXT BTN HANDLING END
 
@@ -227,3 +241,4 @@ $(function() {
     });
     // INFOBAR END
 });
+

--- a/src/pug/chunk/start_game.pug
+++ b/src/pug/chunk/start_game.pug
@@ -1,4 +1,4 @@
 div.section-outer.section-launch
     div.section-inner.d-flex.justify-content-center.align-items-center
         div.section-header-wrapper__form-button
-            button(id="swiper-js") Start game
+            button(id="start-game-btn") Start game

--- a/src/pug/game.pug
+++ b/src/pug/game.pug
@@ -1,0 +1,9 @@
+extends layout/app
+
+block page
+    div.container.mt-5
+        h1.text-center Game Page
+        p.game-description.text-center Ваша игра скоро начнётся!
+
+block scripts
+    script(src="js/game.js")

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -9,8 +9,9 @@ block page
         include chunk/crew_choice
         include chunk/start_game
         
-    script(src="js/JQuery.js")
-    script(src="js/scripts.js")
+
+block scripts
+    script(src="js/main.js")
 
 //- block modal
 //-     - 

--- a/src/pug/layout/app.pug
+++ b/src/pug/layout/app.pug
@@ -6,9 +6,9 @@ html(lang="en")
         meta(name="viewport", content="width=device-width, initial-scale=1.0")
         title Document
         link(rel="stylesheet", href="css/style.min.css")
-        script(src="js/main.js") 
     body 
         //- div(class="main-wrapper bg-dark text-light") 
         //-     block page
         block page
         block modal
+        block scripts


### PR DESCRIPTION
## Summary
- make layout accept per-page scripts
- add game page and game script
- save selected options on Start game and open new page
- hook up new script blocks in index and game pages

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877570c9c348320b682a9d598434656