### PR TITLE
Add automatic setup restoration and start button check

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -75,6 +75,15 @@ $(function() {
     window.infobar = infobar;
     infobar.activatePagesliderGoHandling();
 
+    const $startGameBtn = $('#start-game-btn');
+    const $swiper = $('#swiper-js');
+    const $commonSwiper = $('.swiper-js');
+
+    const inputName = $('#input-name-js');
+    const inputSurname = $('#input-surname-js');
+    const personName = $('.js-person-name');
+    const personSurname = $('.js-person-surname');
+
     const starshipManager = new choice_managers.StarshipChoiceManager({
         displayingSelector: '#starship',
         eventSelector: '.choice-click-handler-js[data-choice-name=starship]', 
@@ -159,10 +168,6 @@ $(function() {
     const BIND_DELAY = 400;
     let lastWheel = new Date();
 
-    const $swiper = $('#swiper-js');
-    const $commonSwiper = $('.swiper-js'); // next-btn in the bottom of each slide
-    const $startGameBtn = $('#start-game-btn');
-
     const sectionCount = $('.section-outer').length;
     const SCROLL_MAX = (sectionCount * 100) - 100;
     const SCROLL_MIN = 0;
@@ -174,12 +179,7 @@ $(function() {
 
     verification.verifyInputs();
 
-    const personName = $('.js-person-name');
-    const personSurname = $('.js-person-surname');
-
     // NEXT BTN HANDLING
-    const inputName = $('#input-name-js');
-    const inputSurname = $('#input-surname-js');
     $swiper.on("click", (e)=>{
         if(window.isCorrectInputSurname && window.isCorrectInputName){
             personName.text(inputName.val());

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -98,10 +98,51 @@ $(function() {
 
     const crewManager = new choice_managers.CrewChoiceManager({
         displayingSelector: '#js-crew-list',
-        eventSelector: '.choice-click-handler-js[data-choice-name=crew-member]', 
+        eventSelector: '.choice-click-handler-js[data-choice-name=crew-member]',
         idAttr: 'data-choice-id',
         choices: window.readOnlyData.crew
     });
+
+    function updateStartBtnState() {
+        const ready = starshipManager.selectedItems.length >= starshipManager.min &&
+            equipmentManager.selectedItems.length >= equipmentManager.min &&
+            flightpathManager.selectedItems.length >= flightpathManager.min &&
+            crewManager.selectedItems.length >= crewManager.min;
+        $startGameBtn.prop('disabled', !ready);
+    }
+
+    $(document).on('choice:change', updateStartBtnState);
+
+    const savedSetupStr = localStorage.getItem('gameSetup');
+    if (savedSetupStr) {
+        try {
+            const savedSetup = JSON.parse(savedSetupStr);
+            if (savedSetup.name) {
+                inputName.val(savedSetup.name);
+                personName.text(savedSetup.name);
+            }
+            if (savedSetup.surname) {
+                inputSurname.val(savedSetup.surname);
+                personSurname.text(savedSetup.surname);
+            }
+            if (savedSetup.starshipId) {
+                starshipManager.initializeSelection(savedSetup.starshipId);
+            }
+            if (savedSetup.equipmentId) {
+                equipmentManager.initializeSelection(savedSetup.equipmentId);
+            }
+            if (savedSetup.flightpathId) {
+                flightpathManager.initializeSelection(savedSetup.flightpathId);
+            }
+            if (Array.isArray(savedSetup.crewIds)) {
+                crewManager.initializeSelection(savedSetup.crewIds);
+            }
+        } catch (e) {
+            console.error('failed to load gameSetup', e);
+        }
+    }
+
+    updateStartBtnState();
     // const shipManager = new SpaceshipChoiceManager(
     //     {
     //         maxChoices: 3,

--- a/src/js/module/choice_manager.js
+++ b/src/js/module/choice_manager.js
@@ -44,6 +44,7 @@ export class ChoiceManagerAbstract {
         }
 
         this.updateDisplay();
+        $(document).trigger('choice:change');
     }
 
     selectItem(event, itemId) {
@@ -101,6 +102,20 @@ export class StarshipChoiceManager extends ChoiceManagerAbstract {
         let selectedChoice = this.choices.find(choice => choice.id == choiceId);
         $(this.displayingSelector).text(selectedChoice.title_ru);
     }
+
+    initializeSelection(id) {
+        this.selectedItems = [];
+        $(this.eventSelector).removeClass('chosen');
+        if (id) {
+            const $el = $(`${this.eventSelector}[${this.idAttr}=${id}]`);
+            if ($el.length) {
+                this.selectedItems = [id];
+                $el.addClass('chosen');
+            }
+        }
+        this.updateDisplay();
+        $(document).trigger('choice:change');
+    }
 }
 
 
@@ -129,6 +144,20 @@ export class EquipmentChoiceManager extends ChoiceManagerAbstract {
         let selectedChoice = this.choices.find(choice => choice.id == choiceId);
         $(this.displayingSelector).text(selectedChoice.title_ru);
     }
+
+    initializeSelection(id) {
+        this.selectedItems = [];
+        $(this.eventSelector).removeClass('chosen');
+        if (id) {
+            const $el = $(`${this.eventSelector}[${this.idAttr}=${id}]`);
+            if ($el.length) {
+                this.selectedItems = [id];
+                $el.addClass('chosen');
+            }
+        }
+        this.updateDisplay();
+        $(document).trigger('choice:change');
+    }
 }
 
 
@@ -154,6 +183,20 @@ export class FlightpathChoiceManager extends ChoiceManagerAbstract {
         let choiceId = this.selectedItems[0];
         let selectedChoice = this.choices.find(choice => choice.id == choiceId);
         $(this.displayingSelector).text(selectedChoice.title_ru);
+    }
+
+    initializeSelection(id) {
+        this.selectedItems = [];
+        $(this.eventSelector).removeClass('chosen');
+        if (id) {
+            const $el = $(`${this.eventSelector}[${this.idAttr}=${id}]`);
+            if ($el.length) {
+                this.selectedItems = [id];
+                $el.addClass('chosen');
+            }
+        }
+        this.updateDisplay();
+        $(document).trigger('choice:change');
     }
 }
 
@@ -197,5 +240,24 @@ export class CrewChoiceManager extends ChoiceManagerAbstract {
                 });
             $(this.displayingSelector).append(crewEl);
         })
+    }
+
+    initializeSelection(ids=[]) {
+        this.selectedItems = [];
+        $(this.eventSelector).removeClass('chosen');
+        ids.forEach(id => {
+            const $el = $(`${this.eventSelector}[${this.idAttr}=${id}]`);
+            if ($el.length) {
+                this.selectedItems.push(id);
+                $el.addClass('chosen');
+            }
+        });
+        if (this.selectedItems.length >= this.max) {
+            $(this.choicesContainerSelector).addClass('limit-reached');
+        } else {
+            $(this.choicesContainerSelector).removeClass('limit-reached');
+        }
+        this.updateDisplay();
+        $(document).trigger('choice:change');
     }
 }

--- a/src/pug/chunk/start_game.pug
+++ b/src/pug/chunk/start_game.pug
@@ -1,4 +1,4 @@
 div.section-outer.section-launch
     div.section-inner.d-flex.justify-content-center.align-items-center
         div.section-header-wrapper__form-button
-            button(id="start-game-btn") Start game
+            button(id="start-game-btn" disabled) Start game


### PR DESCRIPTION
## Summary
- disable the "Start game" button in markup
- add helper functions in choice managers to set selections programmatically
- emit a `choice:change` event on every change
- auto-load saved setup from localStorage and enable the start button only when all choices are made

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877668aba508320bcb9a3045a233b7e